### PR TITLE
Fix CI Workflow and Update Dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run lint -- --max-warnings -1
+      - run: npm run lint -- --max-warnings=0
       - run: npx prettier --check src_front/src
 
       - run: npm test -- --run

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv
 gunicorn
 Pillow
 requests
-ruff
-pytest
+ruff==0.15.11
+pytest==9.0.3
 pytest-flask
 coverage

--- a/src_front/src/pages/HobbyList.tsx
+++ b/src_front/src/pages/HobbyList.tsx
@@ -41,7 +41,7 @@ export default function HobbyList() {
       .then((r) => setHobbies(r.data))
       .catch(onErr)
       .finally(() => setLoading(false))
-  }, [])
+  }, [onErr])
 
   const handleCreate = async () => {
     if (!name) return
@@ -166,7 +166,11 @@ export default function HobbyList() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setEditTarget(null)}>Cancel</Button>
-          <Button onClick={handleEdit} variant="contained" disabled={editName.trim() === ''}>
+          <Button
+            onClick={handleEdit}
+            variant="contained"
+            disabled={editName.trim() === ''}
+          >
             Save
           </Button>
         </DialogActions>

--- a/src_front/src/test/PonyList.test.tsx
+++ b/src_front/src/test/PonyList.test.tsx
@@ -5,10 +5,12 @@ import PonyList from '../pages/PonyList'
 import * as poniesApi from '../api/ponies'
 import * as friendshipsApi from '../api/friendships'
 import * as hobbiesApi from '../api/hobbies'
+import * as generationsApi from '../api/generations'
 
 vi.mock('../api/ponies')
 vi.mock('../api/friendships')
 vi.mock('../api/hobbies')
+vi.mock('../api/generations')
 
 const mockListPonies = vi.mocked(poniesApi.listPonies)
 const mockDeletePony = vi.mocked(poniesApi.deletePony)
@@ -31,6 +33,7 @@ beforeEach(() => {
   vi.mocked(friendshipsApi.listFriendshipHobbies).mockResolvedValue({ data: [] } as never)
   vi.mocked(hobbiesApi.listHobbies).mockResolvedValue({ data: [] } as never)
   vi.mocked(hobbiesApi.listPonyHobbies).mockResolvedValue({ data: [] } as never)
+  vi.mocked(generationsApi.listGenerations).mockResolvedValue({ data: [] } as never)
 })
 
 describe('PonyList', () => {


### PR DESCRIPTION
## Summary
- Fix CI lint flag from `--max-warnings -1` to `--max-warnings=0`
- Pin `ruff` and `pytest` to specific versions in requirements.txt
- Add `onErr` to `useEffect` dependency array in HobbyList
- Add `generationsApi` mock to PonyList tests

## Test plan
- [ ] CI workflow passes without lint errors
- [ ] Frontend tests pass with the updated generations mock
- [ ] HobbyList loads without React hook warnings