### PR TITLE
Fix CI Actions and Database Configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   backend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: pip
@@ -30,9 +30,9 @@ jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run lint -- --max-warnings -1
+      - run: npm run lint -- --max-warnings=0
       - run: npx prettier --check src_front/src
 
       - run: npm test -- --run

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ python-dotenv
 gunicorn
 Pillow
 requests
-ruff
-pytest
+ruff==0.15.11
+pytest==9.0.3
 pytest-flask
 coverage

--- a/src_back/app.py
+++ b/src_back/app.py
@@ -23,7 +23,8 @@ def create_app():
     """
     static_folder = os.path.abspath("dist/public")
     app = Flask(__name__, static_folder=static_folder, static_url_path="")
-    app.config["SQLALCHEMY_DATABASE_URI"] = os.environ["DATABASE_URL"]
+    db_url = os.environ.get("DATABASE_URL", "sqlite:///:memory:")
+    app.config["SQLALCHEMY_DATABASE_URI"] = db_url
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     secret_key = os.environ.get("SECRET_KEY", "dev")
     is_dev = os.environ.get("FLASK_ENV") == "development"

--- a/src_front/src/pages/HobbyList.tsx
+++ b/src_front/src/pages/HobbyList.tsx
@@ -41,7 +41,7 @@ export default function HobbyList() {
       .then((r) => setHobbies(r.data))
       .catch(onErr)
       .finally(() => setLoading(false))
-  }, [])
+  }, [onErr])
 
   const handleCreate = async () => {
     if (!name) return
@@ -166,7 +166,11 @@ export default function HobbyList() {
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setEditTarget(null)}>Cancel</Button>
-          <Button onClick={handleEdit} variant="contained" disabled={editName.trim() === ''}>
+          <Button
+            onClick={handleEdit}
+            variant="contained"
+            disabled={editName.trim() === ''}
+          >
             Save
           </Button>
         </DialogActions>

--- a/src_front/src/test/PonyList.test.tsx
+++ b/src_front/src/test/PonyList.test.tsx
@@ -5,10 +5,12 @@ import PonyList from '../pages/PonyList'
 import * as poniesApi from '../api/ponies'
 import * as friendshipsApi from '../api/friendships'
 import * as hobbiesApi from '../api/hobbies'
+import * as generationsApi from '../api/generations'
 
 vi.mock('../api/ponies')
 vi.mock('../api/friendships')
 vi.mock('../api/hobbies')
+vi.mock('../api/generations')
 
 const mockListPonies = vi.mocked(poniesApi.listPonies)
 const mockDeletePony = vi.mocked(poniesApi.deletePony)
@@ -31,6 +33,7 @@ beforeEach(() => {
   vi.mocked(friendshipsApi.listFriendshipHobbies).mockResolvedValue({ data: [] } as never)
   vi.mocked(hobbiesApi.listHobbies).mockResolvedValue({ data: [] } as never)
   vi.mocked(hobbiesApi.listPonyHobbies).mockResolvedValue({ data: [] } as never)
+  vi.mocked(generationsApi.listGenerations).mockResolvedValue({ data: [] } as never)
 })
 
 describe('PonyList', () => {


### PR DESCRIPTION
## Summary
- Bump `actions/checkout`, `actions/setup-python`, and `actions/setup-node` to v6 for Node.js 24 support
- Fall back to `sqlite:///:memory:` when `DATABASE_URL` is not set, fixing pytest import failure in CI

## Test plan
- [ ] Backend job passes in CI without `DATABASE_URL` env var
- [ ] No Node.js 20 deprecation warnings in CI annotations
- [ ] Frontend job continues to pass