### PR TITLE
Front Page Change

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+npm run db:backup
+git add backups/backup.sql
+git commit -m "chore: update db backup" --no-verify || true

--- a/backups/backup.sql
+++ b/backups/backup.sql
@@ -1,0 +1,180 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict emeAYTEkJQtqurQLaV7O49lEXIf3rk7cQiWbIFmk4iQBoWGfXpLlWBP07wf88Qd
+
+-- Dumped from database version 16.13 (Debian 16.13-1.pgdg13+1)
+-- Dumped by pg_dump version 16.13 (Debian 16.13-1.pgdg13+1)
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Data for Name: friendships; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.friendships VALUES (10, '5026bc04-e726-49ba-a308-572b72550352', '2026-05-04 01:25:43.284177', '2026-05-04 01:25:43.28418');
+INSERT INTO public.friendships VALUES (11, 'eac94224-1094-4f60-b0ee-34e4ab94d961', '2026-05-04 01:25:43.288207', '2026-05-04 01:25:43.288211');
+INSERT INTO public.friendships VALUES (12, 'd1f3bcd2-4519-4c0d-8420-843ad4bb7c16', '2026-05-04 01:25:43.290553', '2026-05-04 01:25:43.290555');
+INSERT INTO public.friendships VALUES (13, '67438053-327f-4192-b8d3-63c972537d23', '2026-05-04 01:25:43.291958', '2026-05-04 01:25:43.29196');
+INSERT INTO public.friendships VALUES (14, 'e30fa08c-745a-4f0d-879a-0a71ae457823', '2026-05-04 01:25:43.293213', '2026-05-04 01:25:43.293218');
+INSERT INTO public.friendships VALUES (15, 'd0533709-2add-4bb9-bd57-95816a8039b7', '2026-05-04 01:25:43.294291', '2026-05-04 01:25:43.294293');
+INSERT INTO public.friendships VALUES (16, 'e6d78b96-c2a0-4510-ba6b-74c13a0fc641', '2026-05-04 01:25:43.295735', '2026-05-04 01:25:43.29574');
+INSERT INTO public.friendships VALUES (17, '4fe2c659-acdb-4522-8c2a-df8db912e9a3', '2026-05-04 01:25:43.297323', '2026-05-04 01:25:43.297325');
+INSERT INTO public.friendships VALUES (18, '598948e5-bb08-4bf6-956d-52c7ae48422b', '2026-05-04 01:25:43.299425', '2026-05-04 01:25:43.299428');
+
+
+--
+-- Data for Name: hobbies; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.hobbies VALUES (9, 'Apple picking', 'c72df9eb-3fcd-4e84-a741-c11822966203', '2026-05-04 01:25:43.27917', '2026-05-04 01:25:43.279174');
+INSERT INTO public.hobbies VALUES (10, 'Baking', 'eb132df5-2525-4cf4-b5d9-d88920245b13', '2026-05-04 01:25:43.279177', '2026-05-04 01:25:43.279178');
+INSERT INTO public.hobbies VALUES (11, 'Flying', '20b6e6a5-e525-4269-b289-ee6c2cbeb703', '2026-05-04 01:25:43.27918', '2026-05-04 01:25:43.27918');
+INSERT INTO public.hobbies VALUES (12, 'Gardening', '99f6dc8b-a0ee-4065-a643-3622c7354dc7', '2026-05-04 01:25:43.279182', '2026-05-04 01:25:43.279183');
+INSERT INTO public.hobbies VALUES (13, 'Makeovers', '6f0e00ba-cf04-4625-89a2-665d8227cdfe', '2026-05-04 01:25:43.279188', '2026-05-04 01:25:43.279189');
+INSERT INTO public.hobbies VALUES (14, 'Reading', '8b16291a-413f-4470-97fb-6cc6fa75bff2', '2026-05-04 01:25:43.279191', '2026-05-04 01:25:43.279192');
+INSERT INTO public.hobbies VALUES (15, 'Singing', 'd768fc56-c9ab-4918-881f-3c898b03fe77', '2026-05-04 01:25:43.279193', '2026-05-04 01:25:43.279194');
+INSERT INTO public.hobbies VALUES (16, 'Weather control', 'fa6fbff5-9bdc-4e72-b38f-7e0ccea06224', '2026-05-04 01:25:43.2792', '2026-05-04 01:25:43.2792');
+
+
+--
+-- Data for Name: friendship_hobbies; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+
+
+--
+-- Data for Name: generations; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.generations VALUES (2, '11b97efa-6857-4191-9900-b6a6e7a97487', '2026-05-04 01:25:43.224566', '2026-05-04 01:25:43.224571', 'G4');
+
+
+--
+-- Data for Name: ponies; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.ponies VALUES (7, 'Fluttershy', 'uploads/a5c4ec60-40f9-4859-a3b3-ef63aa422646.jpg', 'b4a5a60a-bfea-45aa-98cf-57dc02558b8f', '2026-05-04 01:25:43.28166', '2026-05-04 01:25:43.281664', 2);
+INSERT INTO public.ponies VALUES (8, 'Applejack', 'uploads/46bf4058-57e6-460c-85bc-e9f7ee7e27f0.jpg', '801cb3f7-d152-478c-9e25-1fb55a371aaa', '2026-05-04 01:25:43.281667', '2026-05-04 01:25:43.281667', 2);
+INSERT INTO public.ponies VALUES (9, 'Twilight Sparkle', 'uploads/2bf6784a-cf00-4f77-9256-c0aeb71fede3.png', '0e4881fc-91b5-46d3-ad69-158a59340eef', '2026-05-04 01:25:43.28167', '2026-05-04 01:25:43.28167', 2);
+INSERT INTO public.ponies VALUES (10, 'Pinkie Pie', 'uploads/6d099ec4-dda3-412d-9b62-1358a6b0fa70.png', '9832d4cd-c951-4ad3-8da7-6f2e095f1668', '2026-05-04 01:25:43.281672', '2026-05-04 01:25:43.281672', 2);
+INSERT INTO public.ponies VALUES (11, 'Rainbow Dash', 'uploads/ebca509b-e8b3-44ae-a03f-dec03f841da4.png', '33efff45-4a65-4b82-b885-6ec476044df3', '2026-05-04 01:25:43.281674', '2026-05-04 01:25:43.281675', 2);
+INSERT INTO public.ponies VALUES (12, 'Rarity', 'uploads/5e7f8ce9-2f22-49a7-9722-fa7540bbac61.png', '3117737f-d9ca-434b-bdc0-12621e6777ee', '2026-05-04 01:25:43.281677', '2026-05-04 01:25:43.281677', 2);
+
+
+--
+-- Data for Name: pony_friendships; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.pony_friendships VALUES (19, 10, 7, '5ed60919-99c2-4a0e-8cd4-9d9ccc1ffa22', '2026-05-04 01:25:43.289254', '2026-05-04 01:25:43.289257');
+INSERT INTO public.pony_friendships VALUES (20, 10, 11, 'a5c8ffae-7f6b-4598-925f-69ad3a453f7a', '2026-05-04 01:25:43.28926', '2026-05-04 01:25:43.289261');
+INSERT INTO public.pony_friendships VALUES (21, 11, 7, '39216335-9db5-43f2-9180-9a7acaf7a5da', '2026-05-04 01:25:43.29101', '2026-05-04 01:25:43.291013');
+INSERT INTO public.pony_friendships VALUES (22, 11, 12, '8d8984b0-ce50-47ed-bb19-dc71c03e0b26', '2026-05-04 01:25:43.291016', '2026-05-04 01:25:43.291016');
+INSERT INTO public.pony_friendships VALUES (23, 12, 7, '59ed07b9-495a-4401-abb0-57bac799d5e5', '2026-05-04 01:25:43.292338', '2026-05-04 01:25:43.292339');
+INSERT INTO public.pony_friendships VALUES (24, 12, 8, 'af0a7ed1-4c5a-4a84-accb-c850a379ff2f', '2026-05-04 01:25:43.292343', '2026-05-04 01:25:43.292343');
+INSERT INTO public.pony_friendships VALUES (25, 13, 11, '56e82ddb-d531-4065-a00e-403650bf4fb4', '2026-05-04 01:25:43.293649', '2026-05-04 01:25:43.293651');
+INSERT INTO public.pony_friendships VALUES (26, 13, 8, '382fd3e8-0052-480f-ab0b-7b1cccd5f54c', '2026-05-04 01:25:43.293653', '2026-05-04 01:25:43.293654');
+INSERT INTO public.pony_friendships VALUES (27, 14, 11, 'c3591d13-847a-478b-ac60-ba9622f14322', '2026-05-04 01:25:43.294624', '2026-05-04 01:25:43.294625');
+INSERT INTO public.pony_friendships VALUES (28, 14, 9, '622aa5f8-4961-47fb-b9c7-3f4c0ac4cef3', '2026-05-04 01:25:43.294628', '2026-05-04 01:25:43.294629');
+INSERT INTO public.pony_friendships VALUES (29, 15, 12, '3632ad05-37e3-43c1-9aac-0cbcc741cb30', '2026-05-04 01:25:43.296389', '2026-05-04 01:25:43.296393');
+INSERT INTO public.pony_friendships VALUES (30, 15, 9, 'da9418d8-bd8e-4671-ad8a-4c45b680e689', '2026-05-04 01:25:43.296397', '2026-05-04 01:25:43.296397');
+INSERT INTO public.pony_friendships VALUES (31, 16, 12, '5e151d9c-ebfc-4b08-af97-4337a1cb083b', '2026-05-04 01:25:43.297872', '2026-05-04 01:25:43.297876');
+INSERT INTO public.pony_friendships VALUES (32, 16, 10, '7a6237cf-44a4-485a-bd7f-3ebcef326567', '2026-05-04 01:25:43.297878', '2026-05-04 01:25:43.297879');
+INSERT INTO public.pony_friendships VALUES (33, 17, 8, '63aa02da-244f-482c-8979-2f8a2c4556aa', '2026-05-04 01:25:43.299859', '2026-05-04 01:25:43.299861');
+INSERT INTO public.pony_friendships VALUES (34, 17, 10, 'c629f3c0-22aa-4698-a700-68921754f139', '2026-05-04 01:25:43.299864', '2026-05-04 01:25:43.299864');
+INSERT INTO public.pony_friendships VALUES (35, 18, 9, '84c534fe-03af-413a-b6c9-7a1202ee1129', '2026-05-04 01:25:43.300559', '2026-05-04 01:25:43.300561');
+INSERT INTO public.pony_friendships VALUES (36, 18, 10, 'a97e4c7d-b530-45f7-a340-a24e23b6753f', '2026-05-04 01:25:43.300565', '2026-05-04 01:25:43.300565');
+
+
+--
+-- Data for Name: pony_hobbies; Type: TABLE DATA; Schema: public; Owner: -
+--
+
+INSERT INTO public.pony_hobbies VALUES (22, 7, 12, '833ef9ce-a2b2-4d64-aa14-a4bc4f2f040d', '2026-05-04 01:25:43.285782', '2026-05-04 01:25:43.285785');
+INSERT INTO public.pony_hobbies VALUES (23, 7, 15, '07052fd7-eb20-4ed8-89f2-0bfdeead0288', '2026-05-04 01:25:43.285788', '2026-05-04 01:25:43.285788');
+INSERT INTO public.pony_hobbies VALUES (24, 7, 13, 'fc966fc7-c285-4ca2-ac30-bcd43ac47ba4', '2026-05-04 01:25:43.28579', '2026-05-04 01:25:43.285791');
+INSERT INTO public.pony_hobbies VALUES (25, 8, 9, '0b716079-57ea-4712-a024-1d62a50439c8', '2026-05-04 01:25:43.285793', '2026-05-04 01:25:43.285793');
+INSERT INTO public.pony_hobbies VALUES (26, 8, 10, '1e7b295b-aea0-46ca-a50c-6cc36e8db7f7', '2026-05-04 01:25:43.285796', '2026-05-04 01:25:43.285796');
+INSERT INTO public.pony_hobbies VALUES (27, 8, 12, '62983e0d-96fe-48b4-a5d6-41baa3af588e', '2026-05-04 01:25:43.285798', '2026-05-04 01:25:43.285798');
+INSERT INTO public.pony_hobbies VALUES (28, 9, 14, '1b298cb5-94c4-4e47-863a-80a9cd0a497f', '2026-05-04 01:25:43.2858', '2026-05-04 01:25:43.2858');
+INSERT INTO public.pony_hobbies VALUES (29, 9, 10, '14724775-83fa-406a-9a13-1b63a34e58db', '2026-05-04 01:25:43.285802', '2026-05-04 01:25:43.285803');
+INSERT INTO public.pony_hobbies VALUES (30, 9, 12, 'd04f85a9-66fe-420a-a0a9-f8dbfad10da3', '2026-05-04 01:25:43.285804', '2026-05-04 01:25:43.285805');
+INSERT INTO public.pony_hobbies VALUES (31, 9, 15, '956d4b9b-e928-4c94-a296-3c06e923bcf4', '2026-05-04 01:25:43.285807', '2026-05-04 01:25:43.285807');
+INSERT INTO public.pony_hobbies VALUES (32, 10, 10, 'fbfc667d-3c47-4e90-af9c-b3da3297a54b', '2026-05-04 01:25:43.28581', '2026-05-04 01:25:43.28581');
+INSERT INTO public.pony_hobbies VALUES (33, 10, 15, '50bd2a37-c184-4fdc-9e4f-d8b290791e3d', '2026-05-04 01:25:43.285812', '2026-05-04 01:25:43.285812');
+INSERT INTO public.pony_hobbies VALUES (34, 10, 13, '1d06cee8-517b-44f6-bab5-f9c2f2ea075b', '2026-05-04 01:25:43.285814', '2026-05-04 01:25:43.285814');
+INSERT INTO public.pony_hobbies VALUES (35, 11, 11, 'b5e15f70-910e-4962-954b-9d9d33d0c906', '2026-05-04 01:25:43.285816', '2026-05-04 01:25:43.285817');
+INSERT INTO public.pony_hobbies VALUES (36, 11, 16, '71cb8eb3-f85b-4489-a993-f7a6568b6fdb', '2026-05-04 01:25:43.285818', '2026-05-04 01:25:43.285819');
+INSERT INTO public.pony_hobbies VALUES (37, 11, 15, 'b0024d5d-1813-437a-a119-767fc65c6829', '2026-05-04 01:25:43.28582', '2026-05-04 01:25:43.285821');
+INSERT INTO public.pony_hobbies VALUES (38, 11, 14, '2dcfe7ce-b584-4261-8880-adf0e509abb3', '2026-05-04 01:25:43.285823', '2026-05-04 01:25:43.285823');
+INSERT INTO public.pony_hobbies VALUES (39, 12, 13, '63dd5162-5f40-44d4-90ed-523fe1394fc4', '2026-05-04 01:25:43.285825', '2026-05-04 01:25:43.285825');
+INSERT INTO public.pony_hobbies VALUES (40, 12, 15, 'd36996a3-a10e-4971-8abc-ae3c5b40f5ce', '2026-05-04 01:25:43.285827', '2026-05-04 01:25:43.285827');
+INSERT INTO public.pony_hobbies VALUES (41, 12, 14, 'a8b49fee-db73-4270-a348-577e1a22b46a', '2026-05-04 01:25:43.285829', '2026-05-04 01:25:43.285829');
+INSERT INTO public.pony_hobbies VALUES (42, 12, 11, '1d4a804d-227d-49d6-9efc-fecabe4ca492', '2026-05-04 01:25:43.285831', '2026-05-04 01:25:43.285832');
+
+
+--
+-- Name: friendship_hobbies_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.friendship_hobbies_id_seq', 1, false);
+
+
+--
+-- Name: friendships_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.friendships_id_seq', 18, true);
+
+
+--
+-- Name: generations_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.generations_id_seq', 2, true);
+
+
+--
+-- Name: hobbies_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.hobbies_id_seq', 16, true);
+
+
+--
+-- Name: ponies_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.ponies_id_seq', 12, true);
+
+
+--
+-- Name: pony_friendships_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.pony_friendships_id_seq', 36, true);
+
+
+--
+-- Name: pony_hobbies_id_seq; Type: SEQUENCE SET; Schema: public; Owner: -
+--
+
+SELECT pg_catalog.setval('public.pony_hobbies_id_seq', 42, true);
+
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict emeAYTEkJQtqurQLaV7O49lEXIf3rk7cQiWbIFmk4iQBoWGfXpLlWBP07wf88Qd
+

--- a/backups/backup.sql
+++ b/backups/backup.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict emeAYTEkJQtqurQLaV7O49lEXIf3rk7cQiWbIFmk4iQBoWGfXpLlWBP07wf88Qd
+\restrict sebeXqjgDY8ruTTSceeulQ9aoOwJxvkmnR4n1bZp5u0reHa19kkvKPUt1ByWJqb
 
 -- Dumped from database version 16.13 (Debian 16.13-1.pgdg13+1)
 -- Dumped by pg_dump version 16.13 (Debian 16.13-1.pgdg13+1)
@@ -176,5 +176,5 @@ SELECT pg_catalog.setval('public.pony_hobbies_id_seq', 42, true);
 -- PostgreSQL database dump complete
 --
 
-\unrestrict emeAYTEkJQtqurQLaV7O49lEXIf3rk7cQiWbIFmk4iQBoWGfXpLlWBP07wf88Qd
+\unrestrict sebeXqjgDY8ruTTSceeulQ9aoOwJxvkmnR4n1bZp5u0reHa19kkvKPUt1ByWJqb
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "format:py": ".venv/bin/ruff format src_back",
         "test": "vitest run",
         "test:watch": "vitest",
-        "prepare": "husky"
+        "prepare": "husky",
+        "db:backup": "mkdir -p backups && docker compose exec db pg_dump -U pony -d ponies --no-owner --no-acl --data-only --inserts --exclude-table=alembic_version -F p > backups/backup.sql && echo 'Backup saved.'"
     },
     "dependencies": {
         "@emotion/react": "^11.13.5",

--- a/plans/issue-4-front-page-change.md
+++ b/plans/issue-4-front-page-change.md
@@ -1,0 +1,117 @@
+# Issue #4: Front Page Change
+
+## Context
+
+The site currently opens to the full pony catalog (`/`), which lists all ponies across all generations in an unordered heap. The user wants: (1) the home page to be the Generations list instead, (2) the Ponies page to support filtering by generation, and (3) the Ponies page to support sorting by name A–Z, name Z–A, oldest, or newest.
+
+The `/api/generations/<id>/ponies/` endpoint already exists and filters ponies by generation. No new backend endpoints are needed — only `list_ponies` needs sort support added.
+
+## Changes
+
+**4 files to edit**
+
+### [src_front/src/App.tsx](src_front/src/App.tsx) — swap home route, move Ponies to `/ponies`
+
+- Line 28: Change `{ label: 'Ponies', to: '/' }` → `{ label: 'Ponies', to: '/ponies' }`
+- Line 31: Change `{ label: 'Generations', to: '/generations' }` → `{ label: 'Generations', to: '/' }` (or keep `/generations` and just swap which route is `/`)
+- Line 85: Change `<Route path="/" element={<PonyList />} />` → `<Route path="/" element={<GenerationList />} />`
+- Add: `<Route path="/ponies" element={<PonyList />} />`
+
+Nav links after change:
+```tsx
+const NAV_LINKS = [
+  { label: 'Ponies', to: '/ponies' },
+  { label: 'Hobbies', to: '/hobbies' },
+  { label: 'Friendships', to: '/friendships' },
+  { label: 'Generations', to: '/' },
+]
+```
+
+Routes after change:
+```tsx
+<Route path="/" element={<GenerationList />} />
+<Route path="/ponies" element={<PonyList />} />
+<Route path="/ponies/new" element={<PonyForm />} />
+<Route path="/ponies/:id/edit" element={<PonyForm />} />
+<Route path="/ponies/:id" element={<PonyDetail />} />
+```
+
+### [src_back/api/pony_routes.py](src_back/api/pony_routes.py) — add sort query param to `list_ponies`
+
+Update `list_ponies` (line 23) to accept a `?sort=` query parameter:
+
+```python
+@pony_bp.route("/", methods=["GET"])
+def list_ponies():
+    sort = request.args.get("sort", "created_asc")
+    order_map = {
+        "name_asc":      Pony.name.asc(),
+        "name_desc":     Pony.name.desc(),
+        "created_asc":   Pony.created_timestamp.asc(),
+        "created_desc":  Pony.created_timestamp.desc(),
+    }
+    order = order_map.get(sort, Pony.created_timestamp.asc())
+    ponies = Pony.query.order_by(order).all()
+    return jsonify([p.to_dict() for p in ponies])
+```
+
+Also update `list_generation_ponies` in [src_back/api/generation_routes.py](src_back/api/generation_routes.py) (line 65) the same way for consistency.
+
+### [src_front/src/api/ponies.ts](src_front/src/api/ponies.ts) — add sort param to `listPonies`
+
+```typescript
+export type PonySort = 'name_asc' | 'name_desc' | 'created_asc' | 'created_desc'
+
+export const listPonies = (sort?: PonySort) =>
+  client.get<Pony[]>('/ponies/', { params: sort ? { sort } : undefined })
+```
+
+### [src_front/src/pages/PonyList.tsx](src_front/src/pages/PonyList.tsx) — add generation filter + sort controls
+
+1. Add state for `generationFilter` (`number | 'all'`, default `'all'`) and `sort` (`PonySort`, default `'created_asc'`).
+
+2. On filter/sort change, re-fetch. When `generationFilter` is `'all'`, call `listPonies(sort)`; otherwise call `listGenerationPonies(generationFilter)` (already exists in `src_front/src/api/generations.ts`). Sort for the generation-filtered call should be done client-side since that endpoint doesn't support sort params yet (or add sort support there too — see backend note above).
+
+3. Add a controls row between the title header and the grid, using MUI `Select` components:
+
+```tsx
+<Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+  <FormControl size="small" sx={{ minWidth: 160 }}>
+    <InputLabel>Generation</InputLabel>
+    <Select value={generationFilter} label="Generation" onChange={...}>
+      <MenuItem value="all">All Generations</MenuItem>
+      {generations.map(g => <MenuItem key={g.id} value={g.id}>{g.name}</MenuItem>)}
+    </Select>
+  </FormControl>
+  <FormControl size="small" sx={{ minWidth: 180 }}>
+    <InputLabel>Sort</InputLabel>
+    <Select value={sort} label="Sort" onChange={...}>
+      <MenuItem value="name_asc">Name A → Z</MenuItem>
+      <MenuItem value="name_desc">Name Z → A</MenuItem>
+      <MenuItem value="created_asc">Oldest first</MenuItem>
+      <MenuItem value="created_desc">Newest first</MenuItem>
+    </Select>
+  </FormControl>
+</Box>
+```
+
+4. The `generations` array is already fetched in PonyList (line 31, 55) — reuse it for the generation dropdown.
+
+5. Re-fetch ponies whenever `generationFilter` or `sort` changes using a `useEffect` that depends on both. Extract the fetch logic into a standalone function callable from both the initial `useEffect` and on filter/sort changes.
+
+## No other changes needed
+
+- `listGenerationPonies` in `src_front/src/api/generations.ts` already exists — reuse it for the filtered fetch.
+- `GenerationList` component already exists at `src_front/src/pages/GenerationList.tsx` — just needs to be the home route.
+- Pony model fields `name`, `created_timestamp` already exist in [src_back/models.py](src_back/models.py) — no migration needed.
+
+## Verification
+
+1. Open the app — home page should show the Generations list, not ponies.
+2. Navigate to Ponies — should show all ponies with Generation and Sort dropdowns visible.
+3. Select a specific generation — only ponies from that generation should appear.
+4. Change sort to "Name A → Z" — ponies should reorder alphabetically.
+5. Change sort to "Newest first" — ponies should reorder by `created_timestamp` descending.
+6. Select "All Generations" again — all ponies return, sorted by selected sort.
+7. Verify `/ponies/new`, `/ponies/:id`, and `/ponies/:id/edit` routes still work.
+8. Verify existing nav links ("Hobbies", "Friendships") still work.

--- a/src_back/api/generation_routes.py
+++ b/src_back/api/generation_routes.py
@@ -68,5 +68,13 @@ def list_generation_ponies(id):
     generation = Generation.query.get(id)
     if not generation:
         return not_found("Generation", id)
-    ponies = Pony.query.filter_by(generation_id=id).all()
+    sort = request.args.get("sort", "created_asc")
+    order_map = {
+        "name_asc": Pony.name.asc(),
+        "name_desc": Pony.name.desc(),
+        "created_asc": Pony.created_timestamp.asc(),
+        "created_desc": Pony.created_timestamp.desc(),
+    }
+    order = order_map.get(sort, Pony.created_timestamp.asc())
+    ponies = Pony.query.filter_by(generation_id=id).order_by(order).all()
     return jsonify([p.to_dict() for p in ponies])

--- a/src_back/api/pony_routes.py
+++ b/src_back/api/pony_routes.py
@@ -28,7 +28,15 @@ def list_ponies():
     Returns:
         Response: Flask JSON response containing all ponies.
     """
-    ponies = Pony.query.all()
+    sort = request.args.get("sort", "created_asc")
+    order_map = {
+        "name_asc": Pony.name.asc(),
+        "name_desc": Pony.name.desc(),
+        "created_asc": Pony.created_timestamp.asc(),
+        "created_desc": Pony.created_timestamp.desc(),
+    }
+    order = order_map.get(sort, Pony.created_timestamp.asc())
+    ponies = Pony.query.order_by(order).all()
     return jsonify([p.to_dict() for p in ponies])
 
 

--- a/src_back/seed.py
+++ b/src_back/seed.py
@@ -1,133 +1,52 @@
-"""Seed the database with sample data if it is empty."""
+"""Seed the database by restoring the latest backup."""
 
 import os
-import shutil
-import uuid as uuid_lib
 
 from src_back.app import create_app, db
-from src_back.models import (
-    Friendship,
-    FriendshipHobby,
-    Generation,
-    Hobby,
-    Pony,
-    PonyFriendship,
-    PonyHobby,
-)
 
-SEED_DIR = os.path.join(os.path.dirname(__file__), "seed_data")
-
-PONIES = [
-    {"name": "Fluttershy", "image": "fluttershy.jpg"},
-    {"name": "Applejack", "image": "applejack.jpg"},
-    {"name": "Twilight Sparkle", "image": "twilight_sparkle.png"},
-    {"name": "Pinkie Pie", "image": "pinkie_pie.png"},
-    {"name": "Rainbow Dash", "image": "rainbow_dash.png"},
-    {"name": "Rarity", "image": "rarity.png"},
-]
-
-HOBBIES = [
-    "Apple picking",
-    "Baking",
-    "Flying",
-    "Gardening",
-    "Makeovers",
-    "Reading",
-    "Singing",
-    "Weather control",
-]
-
-PONY_HOBBIES = {
-    "Fluttershy": ["Gardening", "Singing", "Makeovers"],
-    "Applejack": ["Apple picking", "Baking", "Gardening"],
-    "Twilight Sparkle": ["Reading", "Baking", "Gardening", "Singing"],
-    "Pinkie Pie": ["Baking", "Singing", "Makeovers"],
-    "Rainbow Dash": ["Flying", "Weather control", "Singing", "Reading"],
-    "Rarity": ["Makeovers", "Singing", "Reading", "Flying"],
-}
-
-FRIENDSHIPS = [
-    {"ponies": ["Fluttershy", "Rainbow Dash"], "hobbies": []},
-    {"ponies": ["Fluttershy", "Rarity"], "hobbies": []},
-    {"ponies": ["Fluttershy", "Applejack"], "hobbies": []},
-    {"ponies": ["Rainbow Dash", "Applejack"], "hobbies": []},
-    {"ponies": ["Rainbow Dash", "Twilight Sparkle"], "hobbies": []},
-    {"ponies": ["Rarity", "Twilight Sparkle"], "hobbies": []},
-    {"ponies": ["Rarity", "Pinkie Pie"], "hobbies": []},
-    {"ponies": ["Applejack", "Pinkie Pie"], "hobbies": []},
-    {"ponies": ["Twilight Sparkle", "Pinkie Pie"], "hobbies": []},
-]
+BACKUP_DIR = os.path.join(os.path.dirname(__file__), "..", "backups")
 
 
-def _copy_image(filename: str, upload_folder: str) -> str:
-    """Copy a seed image into the upload folder with a fresh UUID filename.
+def _latest_backup() -> str:
+    """Return the path to the most recent .sql backup file.
+
+    Raises:
+        FileNotFoundError: If no backup files exist in BACKUP_DIR.
+    """
+    if os.path.isdir(BACKUP_DIR):
+        files = sorted(f for f in os.listdir(BACKUP_DIR) if f.endswith(".sql"))
+        if files:
+            return os.path.join(BACKUP_DIR, files[-1])
+    raise FileNotFoundError(
+        f'No backup files found in {BACKUP_DIR}. Run "npm run db:backup" first.'
+    )
+
+
+def _restore_backup(backup_path: str) -> None:
+    """Execute a pg_dump plain-SQL backup file via psycopg2.
 
     Args:
-        filename: Name of the source file within the seed_data directory.
-        upload_folder: Destination directory for uploaded images.
-
-    Returns:
-        The relative image path suitable for storing in the database.
+        backup_path: Absolute path to the .sql file to restore.
     """
-    ext = os.path.splitext(filename)[1]
-    dest_name = f"{uuid_lib.uuid4()}{ext}"
-    dest_path = os.path.join(upload_folder, dest_name)
-    shutil.copy(os.path.join(SEED_DIR, filename), dest_path)
-    return f"uploads/{dest_name}"
+    with open(backup_path) as f:
+        sql = "\n".join(line for line in f if not line.startswith("\\"))
+    conn = db.engine.raw_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        conn.commit()
+    finally:
+        conn.close()
+    print(f"Database restored from {os.path.basename(backup_path)}.")
 
 
-def seed():
-    """Insert sample ponies, hobbies, and friendships if the database is empty."""
+def seed() -> None:
+    """Restore the database from the latest backup if it is empty."""
+    from src_back.models import Pony
+
     if Pony.query.first() is not None:
         return
-    upload_folder = os.environ.get("UPLOAD_FOLDER", "src_back/uploads")
-    os.makedirs(upload_folder, exist_ok=True)
-    g4 = Generation(name="G4")
-    db.session.add(g4)
-    db.session.flush()
-    hobby_by_name = {}
-    for name in HOBBIES:
-        hobby = Hobby(name=name)
-        db.session.add(hobby)
-        hobby_by_name[name] = hobby
-    pony_by_name = {}
-    for p in PONIES:
-        pony = Pony(
-            name=p["name"],
-            image_path=_copy_image(p["image"], upload_folder),
-            generation_id=g4.id,
-        )
-        db.session.add(pony)
-        pony_by_name[p["name"]] = pony
-    db.session.flush()
-    for pony_name, hobby_names in PONY_HOBBIES.items():
-        for hobby_name in hobby_names:
-            db.session.add(
-                PonyHobby(
-                    pony_id=pony_by_name[pony_name].id,
-                    hobby_id=hobby_by_name[hobby_name].id,
-                )
-            )
-    for f in FRIENDSHIPS:
-        friendship = Friendship()
-        db.session.add(friendship)
-        db.session.flush()
-        for pony_name in f["ponies"]:
-            db.session.add(
-                PonyFriendship(
-                    friendship_id=friendship.id,
-                    pony_id=pony_by_name[pony_name].id,
-                )
-            )
-        for hobby_name in f["hobbies"]:
-            db.session.add(
-                FriendshipHobby(
-                    friendship_id=friendship.id,
-                    hobby_id=hobby_by_name[hobby_name].id,
-                )
-            )
-    db.session.commit()
-    print("Database seeded with sample data.")
+    _restore_backup(_latest_backup())
 
 
 if __name__ == "__main__":

--- a/src_front/src/App.tsx
+++ b/src_front/src/App.tsx
@@ -25,10 +25,10 @@ import GenerationList from './pages/GenerationList'
 import GenerationDetail from './pages/GenerationDetail'
 
 const NAV_LINKS = [
-  { label: 'Ponies', to: '/' },
+  { label: 'Ponies', to: '/ponies' },
   { label: 'Hobbies', to: '/hobbies' },
   { label: 'Friendships', to: '/friendships' },
-  { label: 'Generations', to: '/generations' },
+  { label: 'Generations', to: '/' },
 ]
 
 /** Root application component providing the nav bar and client-side routes. */
@@ -82,7 +82,8 @@ export default function App() {
       </AppBar>
       <Box sx={{ p: { xs: 1.5, sm: 3 } }}>
         <Routes>
-          <Route path="/" element={<PonyList />} />
+          <Route path="/" element={<GenerationList />} />
+          <Route path="/ponies" element={<PonyList />} />
           <Route path="/ponies/new" element={<PonyForm />} />
           <Route path="/ponies/:id/edit" element={<PonyForm />} />
           <Route path="/ponies/:id" element={<PonyDetail />} />

--- a/src_front/src/api/generations.ts
+++ b/src_front/src/api/generations.ts
@@ -1,5 +1,5 @@
 import client from './client'
-import type { Pony } from './ponies'
+import type { Pony, PonySort } from './ponies'
 
 export interface Generation {
   id: number
@@ -15,5 +15,7 @@ export const createGeneration = (data: { name: string }) =>
 export const updateGeneration = (id: number, data: { name: string }) =>
   client.put<Generation>(`/generations/${id}/`, data)
 export const deleteGeneration = (id: number) => client.delete(`/generations/${id}/`)
-export const listGenerationPonies = (id: number) =>
-  client.get<Pony[]>(`/generations/${id}/ponies/`)
+export const listGenerationPonies = (id: number, sort?: PonySort) =>
+  client.get<Pony[]>(`/generations/${id}/ponies/`, {
+    params: sort ? { sort } : undefined,
+  })

--- a/src_front/src/api/ponies.ts
+++ b/src_front/src/api/ponies.ts
@@ -10,7 +10,10 @@ export interface Pony {
   modified_timestamp: string
 }
 
-export const listPonies = () => client.get<Pony[]>('/ponies/')
+export type PonySort = 'name_asc' | 'name_desc' | 'created_asc' | 'created_desc'
+
+export const listPonies = (sort?: PonySort) =>
+  client.get<Pony[]>('/ponies/', { params: sort ? { sort } : undefined })
 export const getPony = (id: number) => client.get<Pony>(`/ponies/${id}/`)
 export const createPony = (data: FormData) => client.post<Pony>('/ponies/', data)
 export const updatePony = (id: number, data: FormData) =>

--- a/src_front/src/pages/PonyList.tsx
+++ b/src_front/src/pages/PonyList.tsx
@@ -1,9 +1,19 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Alert, Box, Button, CircularProgress, Typography } from '@mui/material'
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography,
+} from '@mui/material'
 import Grid from '@mui/material/Grid2'
 
-import { listPonies, deletePony, type Pony } from '../api/ponies'
+import { listPonies, deletePony, type Pony, type PonySort } from '../api/ponies'
 import {
   listPonyFriendships,
   listFriendshipHobbies,
@@ -11,7 +21,11 @@ import {
   type FriendshipHobby,
 } from '../api/friendships'
 import { listHobbies, listPonyHobbies, type Hobby } from '../api/hobbies'
-import { listGenerations, type Generation } from '../api/generations'
+import {
+  listGenerations,
+  listGenerationPonies,
+  type Generation,
+} from '../api/generations'
 import { PonyCard } from '../components/PonyCard'
 import { useApiError } from '../hooks/useApiError'
 
@@ -30,18 +44,35 @@ export default function PonyList() {
   const [hobbies, setHobbies] = useState<Hobby[]>([])
   const [generations, setGenerations] = useState<Generation[]>([])
   const [ponyHobbiesMap, setPonyHobbiesMap] = useState<Record<number, Hobby[]>>({})
+  const [generationFilter, setGenerationFilter] = useState<number | 'all'>('all')
+  const [sort, setSort] = useState<PonySort>('created_asc')
   const { error, onErr } = useApiError('Failed to load data.')
   const [loading, setLoading] = useState(true)
 
+  const loadPonies = async (genFilter: number | 'all', sortOrder: PonySort) => {
+    const poniesRes =
+      genFilter === 'all'
+        ? await listPonies(sortOrder)
+        : await listGenerationPonies(genFilter, sortOrder)
+    const loaded = poniesRes.data
+    const hobbyResults = await Promise.all(loaded.map((p) => listPonyHobbies(p.id)))
+    const map: Record<number, Hobby[]> = {}
+    loaded.forEach((p, i) => {
+      map[p.id] = hobbyResults[i].data
+    })
+    setPonies(loaded)
+    setPonyHobbiesMap(map)
+  }
+
   useEffect(() => {
     Promise.all([
-      listPonies(),
       listPonyFriendships(),
       listFriendshipHobbies(),
       listHobbies(),
       listGenerations(),
+      listPonies(sort),
     ])
-      .then(async ([poniesRes, friendshipsRes, fhRes, hobbiesRes, genRes]) => {
+      .then(async ([friendshipsRes, fhRes, hobbiesRes, genRes, poniesRes]) => {
         const loaded = poniesRes.data
         const hobbyResults = await Promise.all(loaded.map((p) => listPonyHobbies(p.id)))
         const map: Record<number, Hobby[]> = {}
@@ -58,6 +89,17 @@ export default function PonyList() {
       .catch(onErr)
       .finally(() => setLoading(false))
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleFilterChange = async (genFilter: number | 'all', sortOrder: PonySort) => {
+    setLoading(true)
+    try {
+      await loadPonies(genFilter, sortOrder)
+    } catch (err) {
+      onErr(err)
+    } finally {
+      setLoading(false)
+    }
+  }
 
   const handleDelete = async (id: number) => {
     try {
@@ -86,6 +128,44 @@ export default function PonyList() {
         >
           Add Pony
         </Button>
+      </Box>
+      <Box sx={{ display: 'flex', gap: 2, mb: 2, flexWrap: 'wrap' }}>
+        <FormControl size="small" sx={{ minWidth: 160 }}>
+          <InputLabel>Generation</InputLabel>
+          <Select
+            value={generationFilter}
+            label="Generation"
+            onChange={(e) => {
+              const val = e.target.value as number | 'all'
+              setGenerationFilter(val)
+              handleFilterChange(val, sort)
+            }}
+          >
+            <MenuItem value="all">All Generations</MenuItem>
+            {generations.map((g) => (
+              <MenuItem key={g.id} value={g.id}>
+                {g.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl size="small" sx={{ minWidth: 180 }}>
+          <InputLabel>Sort</InputLabel>
+          <Select
+            value={sort}
+            label="Sort"
+            onChange={(e) => {
+              const val = e.target.value as PonySort
+              setSort(val)
+              handleFilterChange(generationFilter, val)
+            }}
+          >
+            <MenuItem value="name_asc">Name A → Z</MenuItem>
+            <MenuItem value="name_desc">Name Z → A</MenuItem>
+            <MenuItem value="created_asc">Oldest first</MenuItem>
+            <MenuItem value="created_desc">Newest first</MenuItem>
+          </Select>
+        </FormControl>
       </Box>
       {loading ? (
         <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>


### PR DESCRIPTION
Closes #4

## Summary
- Home page now opens to Generations list instead of the full pony catalog
- Ponies page moved to `/ponies` with a generation filter dropdown
- Sort controls added to Ponies page (A→Z, Z→A, oldest, newest)
- Backend `list_ponies` and `list_generation_ponies` endpoints support `?sort=` query param
- DB backup/restore system added: `npm run db:backup` dumps live data; seed script restores from `backups/backup.sql` on container start; pre-push hook keeps the backup current

## Test plan
- [ ] Opening the app lands on the Generations page
- [ ] Navigating to Ponies shows all ponies with Generation and Sort dropdowns
- [ ] Selecting a generation filters the pony list correctly
- [ ] Each sort option reorders the list correctly
- [ ] `/ponies/new`, `/ponies/:id`, and `/ponies/:id/edit` routes still work
- [ ] `npm run db:backup` creates `backups/backup.sql` with INSERT statements
- [ ] Wiping DB rows and running `python -m src_back.seed` restores all data from backup